### PR TITLE
Redirect `/mediawiki/` to wiki main page

### DIFF
--- a/mediawiki/.htaccess
+++ b/mediawiki/.htaccess
@@ -16,6 +16,9 @@ RewriteEngine on
 RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^index\.php$ /mediawiki/index.php?title=Main_Page [R,L]
 
+RewriteCond %{QUERY_STRING} ^$
+RewriteRule ^$ /mediawiki/index.php?title=Main_Page [R,L]
+
 RewriteCond %{QUERY_STRING} (.+)&(.+)
 RewriteRule ^(index\.php)$ $1\%3F%1 [L]
 


### PR DESCRIPTION
Before this change, `/mediawiki` was a 301 to `/mediawiki/` because of CheckSpelling, and `/mediawiki/` was a 403 because Apache thinks you are trying to view the contents of that folder and there is no `index.html` present.

However, clearly someone with a link to this is looking for the `mediawiki` main page.

This redirects a request with no path (beyond `mediawiki`) and no query string to the main page.